### PR TITLE
Allow the _ character in property names

### DIFF
--- a/lib/org/lexer.ex
+++ b/lib/org/lexer.ex
@@ -59,7 +59,7 @@ defmodule Org.Lexer do
   @empty_line_re    ~r/^\s*$/
   @table_row_re     ~r/^\s*(?:\|[^|]*)+\|\s*$/
   @begin_props_re   ~r/^\s*\:PROPERTIES\:$/
-  @property_re      ~r/^\s*\:([A-Za-z]+)\:\s*(.+)$/
+  @property_re      ~r/^\s*\:([A-Za-z_]+)\:\s*(.+)$/
   @end_drawer_re    ~r/^\s*\:END\:$/
 
   defp lex_line(line, %Org.Lexer{mode: :normal} = lexer) do

--- a/test/org/lexer_test.exs
+++ b/test/org/lexer_test.exs
@@ -34,6 +34,7 @@ defmodule Org.LexerTest do
       {:property, "Artist", "Glenn Gould"},
       {:property, "Publisher", "Deutsche Grammophon"},
       {:property, "NDisks", "1"},
+      {:property, "ARCHIVE_TIME", "2018-08-14 Tue 16:39"},
       {:end_drawer},
       {:text, "3"},
       {:section_title, 4, "is nesting"},

--- a/test/org/parser_test.exs
+++ b/test/org/parser_test.exs
@@ -39,6 +39,7 @@ defmodule Org.ParserTest do
         {:Artist, "Glenn Gould"},
         {:Publisher, "Deutsche Grammophon"},
         {:NDisks, "1"},
+        {:ARCHIVE_TIME, "2018-08-14 Tue 16:39"},
       ]
     end
   end

--- a/test/org_test.exs
+++ b/test/org_test.exs
@@ -21,11 +21,12 @@ defmodule OrgTest do
   2
   *** thing
       :PROPERTIES:
-      :Title:     Goldberg Variations
-      :Composer:  J.S. Bach
-      :Artist:    Glenn Gould
-      :Publisher: Deutsche Grammophon
-      :NDisks:    1
+      :Title:         Goldberg Variations
+      :Composer:      J.S. Bach
+      :Artist:        Glenn Gould
+      :Publisher:     Deutsche Grammophon
+      :NDisks:        1
+      :ARCHIVE_TIME:  2018-08-14 Tue 16:39
       :END:
   3
   **** is nesting


### PR DESCRIPTION
I use Org archiving, and it adds a property `ARCHIVE_DATE` when I archive an entry.  This was not being parsed properly.  Simple fix I think.  Added test support as well.